### PR TITLE
チャット画面の編集

### DIFF
--- a/app/views/messages/_side_bar.html.erb
+++ b/app/views/messages/_side_bar.html.erb
@@ -5,7 +5,7 @@
     <%= link_to current_user.name, edit_user_path(current_user)  %>
   </div>
   <div class="create-room">
-    <a href="#">チャットを作成する</a>
+    <%= link_to "チャットを作成する", new_room_path %>
   </div>
 </div>
 


### PR DESCRIPTION
サイドバーの「チャット作成」ボタンからチャットルーム新規作成画面へ遷移できなかった部分の修正